### PR TITLE
Added deploy target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ HACK_DIR           := $(REPO_ROOT)/hack
 VERSION            := $(shell cat "$(REPO_ROOT)/VERSION")
 EFFECTIVE_VERSION  := $(VERSION)-$(shell git rev-parse HEAD)
 LD_FLAGS           := ""
+NAMESPACE          := default
 
 .PHONY: start
 start:
@@ -18,6 +19,10 @@ start:
 			--config-file=${CONTROL_KUBECONFIG} \
 			--key-file=${CONTROL_KUBECONFIG} \
 			--postgress-password-file=${CONTROL_KUBECONFIG} \
+
+.PHONY: deploy
+deploy: release
+	helm template ingestor chart/ --values chart/values.yaml | kubectl apply -f - -n $(NAMESPACE)
 
 #################################################################
 # Rules related to formatting and linting                       #


### PR DESCRIPTION
**What this PR does / why we need it**:

Gives us a `deploy` target for cluster deployment in the Makefile

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
