### PR TITLE
Support Gardener cert-controller-manager for ingestor certificates optionally (follow-up)

### DIFF
--- a/charts/falco-event-ingestor/templates/ingestor-certificate.yaml
+++ b/charts/falco-event-ingestor/templates/ingestor-certificate.yaml
@@ -3,6 +3,7 @@ kind: Certificate
 metadata:
 {{- if .Values.ingestor.gardenDNSProvider }}
   annotations:
+    cert.gardener.cloud/class: garden
     cert.gardener.cloud/dnsrecord-provider-type: {{ .Values.ingestor.gardenDNSProvider.type }}
     cert.gardener.cloud/dnsrecord-secret-ref: {{ .Values.ingestor.gardenDNSProvider.secretRef.namespace }}/{{ .Values.ingestor.gardenDNSProvider.secretRef.name }}
     cert.gardener.cloud/dnsrecord-class: garden


### PR DESCRIPTION
**What this PR does / why we need it**:
Missed to set the `cert.gardener.cloud/class` annotation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of #124 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
