### PR TITLE
Adapt falco-event-ingestor to new istio-native exposure

### DIFF
--- a/charts/falco-event-ingestor/templates/ingestor-destinationrule.yaml
+++ b/charts/falco-event-ingestor/templates/ingestor-destinationrule.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   exportTo:
   - '*'
-  host: falco-event-ingestor.falco-event-storage.svc.cluster.local
+  host: falco-event-ingestor.{{ .Release.Namespace }}.svc.cluster.local
   trafficPolicy:
     loadBalancer:
       localityLbSetting:

--- a/charts/falco-event-ingestor/templates/ingestor-destinationrule.yaml
+++ b/charts/falco-event-ingestor/templates/ingestor-destinationrule.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ingestor.useIngress }}
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  labels:
+    app: falco-event-ingestor
+  name: falco-event-ingestor-ingress
+spec:
+  exportTo:
+  - '*'
+  host: falco-event-ingestor.falco-event-storage.svc.cluster.local
+  trafficPolicy:
+    loadBalancer:
+      localityLbSetting:
+        failoverPriority:
+        - topology.kubernetes.io/zone
+        enabled: true
+    connectionPool:
+      tcp:
+        maxConnectionDuration: 86400s
+        tcpKeepalive:
+          interval: 75s
+          time: 7200s
+    outlierDetection: {}
+    tls: {}
+{{- end }}

--- a/charts/falco-event-ingestor/templates/ingestor-gateway.yaml
+++ b/charts/falco-event-ingestor/templates/ingestor-gateway.yaml
@@ -1,35 +1,30 @@
 {{- if .Values.ingestor.useIngress }}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: networking.istio.io/v1
+kind: Gateway
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/use-port-in-redirects: "true"
     cert.gardener.cloud/purpose: managed
 {{- if .Values.ingestor.gardenDNSProvider }}
     cert.gardener.cloud/class: garden
     cert.gardener.cloud/dnsrecord-provider-type: {{ .Values.ingestor.gardenDNSProvider.type }}
     cert.gardener.cloud/dnsrecord-secret-ref: {{ .Values.ingestor.gardenDNSProvider.secretRef.namespace }}/{{ .Values.ingestor.gardenDNSProvider.secretRef.name }}
     cert.gardener.cloud/dnsrecord-class: garden
+    cert.gardener.cloud/secret-namespace: {{ .Values.ingestor.istioNamespace }}
 {{- end }}
   labels:
     app: falco-event-ingestor
   name: falco-event-ingestor-ingress
 spec:
-  ingressClassName: {{ .Values.ingestor.ingressClassName}}
-  rules:
-  - host: {{ .Values.ingestor.ingressDomain }}
-    http:
-      paths:
-      - backend:
-          service:
-            name: falco-event-ingestor
-            port:
-              number: 3200
-        path: /ingestor/api/v1/push
-        pathType: Prefix
-  tls:
+  selector:
+{{ toYaml .Values.ingestor.istioLabels | indent 4 }}
+  servers:
   - hosts:
     - {{ .Values.ingestor.ingressDomain }}
-    secretName: tls-ingestor
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: tls-ingestor
 {{- end }}

--- a/charts/falco-event-ingestor/templates/ingestor-service.yaml
+++ b/charts/falco-event-ingestor/templates/ingestor-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    networking.istio.io/exportTo: "*"
     networking.resources.gardener.cloud/from-world-to-ports: '[{"protocol":"TCP","port":3200}]'
     networking.resources.gardener.cloud/from-all-garden-scrape-targets-allowed-ports: '[{"port":8080,"protocol":"TCP"}]'
     networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'

--- a/charts/falco-event-ingestor/templates/ingestor-virtualservice.yaml
+++ b/charts/falco-event-ingestor/templates/ingestor-virtualservice.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.ingestor.useIngress }}
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  labels:
+    app: falco-event-ingestor
+  name: falco-event-ingestor-ingress
+spec:
+  exportTo:
+  - '*'
+  gateways:
+  - falco-event-ingestor-ingress
+  hosts:
+  - {{ .Values.ingestor.ingressDomain }}
+  http:
+  - match:
+    - uri:
+        prefix: /ingestor/api/v1/push
+    route:
+    - destination:
+        host: falco-event-ingestor.falco-event-storage.svc.cluster.local
+        port:
+          number: 3200
+{{- end }}

--- a/charts/falco-event-ingestor/templates/ingestor-virtualservice.yaml
+++ b/charts/falco-event-ingestor/templates/ingestor-virtualservice.yaml
@@ -18,7 +18,7 @@ spec:
         prefix: /ingestor/api/v1/push
     route:
     - destination:
-        host: falco-event-ingestor.falco-event-storage.svc.cluster.local
+        host: falco-event-ingestor.{{ .Release.Namespace }}.svc.cluster.local
         port:
           number: 3200
 {{- end }}

--- a/charts/falco-event-ingestor/values.yaml
+++ b/charts/falco-event-ingestor/values.yaml
@@ -8,7 +8,9 @@ ingestor:
   clusterDailyEventLimit: 100000000000
   ingestorTLS: false
   useIngress: true
-  ingressClassName: nginx-ingress-gardener
+  istioLabels:
+    istio: ingressgateway
+  istioNamespace: virtual-garden-istio-ingress
   replicas: 2
 ### The gardenDNSProvider section is needed if the garden-runtime cluster uses the garden cert-controller-manager
 ### Values are from the `Garden` resource at `.spec.dns.providers[0]`


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

As `nginx-ingress` is retired, we need to change the exposure of `falco-event-ingestor`, which is currently exposed via `nginx-ingress`. Istio ingress gateway is already deployed everywhere `falco-event-ingestor` is running. Hence, it is a simple choice to switch to it.

Istio allows exposure via a multitude of APIs, among them `Ingress`, istio-native `Gateway`, and Gateway API. The `Ingress` support in istio was never really on par. Hence, we will not use it. Gateway API does not cover all use cases we need. Therefore, we use the same istio-native APIs, which we already use for `kube-apiserver` exposure. This unifies our ingress traffic architecture and simplifies it eventually when `nginx-ingress` is no longer used.

This change is the adaption of `falco-event-ingestor` to istio-native exposure.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/13448

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
falco-event-ingestor is now exposed directly via istio instead of nginx-ingress.
```
